### PR TITLE
Fix checking card number length. 

### DIFF
--- a/sdk/sdk/Card/Card.m
+++ b/sdk/sdk/Card/Card.m
@@ -131,7 +131,7 @@
 +(BOOL) isCardNumberValid: (NSString *) cardNumberString {
     NSString *cleanCardNumber = [Card cleanCreditCardNo:cardNumberString];
     
-    if (cleanCardNumber.length == 0) {
+    if (cleanCardNumber.length < 6 ) {
         return NO;
     }
     


### PR DESCRIPTION
Card length should 6 digits or more for create correct cryptogram string.

In `Card.m` file in method
```objective-c
-(NSString *) makeCardCryptogramPacket: (NSString *) cardNumberString andExpDate: (NSString *) expDateString andCVV: (NSString *) CVVString andMerchantPublicID: (NSString *) merchantPublicIDString
```
can crash on 121 line, if card number lenght less that 6 digits: https://prnt.sc/u4updr
```
*** Terminating app due to uncaught exception ‘NSInvalidArgumentException’, reason: ‘-[__NSCFString substringWithRange:]: Range {0, 6} out of bounds; string length 4’
*** First throw call stack:
(0x1a2e11654 0x1a2b33bcc 0x1a2e67280 0x1a2e67370 0x1a2cf6864 0x1028fc000 0x1029f423c 0x1029fe9f8 0x1029fea5c 0x1a6ec672c 0x1a68d6ed4 0x1a68d722c 0x1a68d6250 0x1a6a97f24 0x1a6a96328 0x1a6a960f4 0x1a6f01c48 0x1a6edd8ec 0x1a6f5e970 0x1a6f614ec 0x1a6f59168 0x1a2d8fad8 0x1a2d8fa30 0x1a2d8f1b8 0x1a2d8a1e8 0x1a2d89ba8 0x1acef9344 0x1a6ec53e4 0x102a9ccb0 0x1a2c118f0)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

And method 
```objective-c
+(BOOL) isCardNumberValid: (NSString *) cardNumberString
```
return true for card number **4242** for example: https://prnt.sc/u4tpqm

Add cheking, that card number have 6 or more digits, for generation correct cryptogram string.
 